### PR TITLE
security: fork-gate all pull_request workflows

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   terraform:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'sentania-labs'
     runs-on: [self-hosted, terraform]
 
     env:


### PR DESCRIPTION
Adds a job-level condition to every workflow that triggers on pull_request (or pull_request_target), restricting execution to PRs whose head repo is owned by sentania-labs. Fork PRs from outside the org are skipped. Defense-in-depth alongside the org-level approval toggle enabled 2026-04-19. Condition: if: github.event_name != pull_request || github.event.pull_request.head.repo.owner.login == sentania-labs. Where jobs already had if:, conditions combined with &&. No logic changes — gate only.