### PR TITLE
docs: overhaul README to match actual repo structure and variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,130 +1,90 @@
 # simpleIaC
-A streamlined Terraform-based framework for deploying **any Aria Automation / VCF Automation blueprint** using a single-pass plan and a clean variable-driven model.
+
+A streamlined Terraform-based framework for deploying **any Aria Automation / VCF Automation blueprint or catalog item** using a single-pass plan and a clean variable-driven model.
 
 This repository provides:
-- A top-level Terraform deployment that accepts environment-specific inputs.
-- A reusable module capable of deploying **any** blueprint by passing inputs dynamically from a `.tfvars` file.
-- Optional output exports for downstream integrations (DNS, CMDB, monitoring, etc.).
+- A top-level Terraform configuration that deploys blueprints and catalog items via the vRA provider.
+- A machine deployment path for direct VM provisioning without a blueprint.
+- Optional output exports (IP addresses, deployment IDs) for downstream integrations.
 
-The design avoids circular dependencies and multi-pass planning by decoupling blueprint resource creation from consumer processes.
-
----
-
-## 🚀 Features
-
-### ✔️ Single-pass Terraform deployment
-The module has been refactored so that:
-- All blueprint inputs come from your `.tfvars` file.
-- Outputs from the deployment are exported without requiring a secondary plan or refresh.
-
-### ✔️ Generic blueprint module
-Feed it:
-- The blueprint ID or name  
-- Input map  
-- Project / region target  
-- Optional metadata and tagging  
-
-The module handles the rest.
-
-### ✔️ Clean separation of concerns
-This repo focuses on **provisioning only**.  
-Any post-provision actions (DNS, CMDB, NSX security, etc.) can be consumed from the outputs.
+The design avoids circular dependencies and multi-pass planning by consuming the `sentania-labs/deployment/vra` and `sentania-labs/machine/vra` registry modules.
 
 ---
 
-## 📁 Repository Structure
+## Repository Structure
 
 ```
 simpleIaC/
-├── main.tf
-├── providers.tf
-├── variables.tf
-├── outputs.tf
+├── backend.tf              # S3 remote state backend
+├── deployments.tf          # Blueprint / catalog item deployments (uses sentania-labs/deployment/vra)
+├── machines.tf             # Direct VM provisioning (uses sentania-labs/machine/vra)
+├── provider.tf             # vRA + DNS provider config
+├── variables.tf            # All input declarations
+├── versions.tf             # Required providers and versions
+├── output-template.tpl     # Templatefile for generating per-VM output
 ├── envs/
-│   ├── lab.tfvars
-│   └── example.tfvars
-└── modules/
-    └── blueprint-deploy/
-        ├── main.tf
-        ├── variables.tf
-        ├── outputs.tf
+│   └── lab.tfvars          # Lab environment example
+└── exampleblueprints/      # Sample blueprint YAML definitions
 ```
 
 ---
 
-## 🧩 Using This Repository
+## Using This Repository
 
 ### 1. Clone the repo
+
 ```bash
 git clone https://github.com/sentania-labs/simpleIaC
 cd simpleIaC
 ```
 
 ### 2. Copy an env file
+
 ```bash
-cp envs/example.tfvars envs/my-env.tfvars
+cp envs/lab.tfvars envs/my-env.tfvars
 ```
 
 ### 3. Edit your TF vars
-Specify:
-- `project_id`
-- `blueprint_id`
-- `deployment_name`
-- `inputs = { ... }`
 
-Example:
+The two primary input maps are `deployments` (blueprint/catalog-item deploys) and `virtual_machines` (direct VM provisions). Example:
+
 ```hcl
-project_id      = "12345"
-blueprint_id    = "bp-abcdef"
-deployment_name = "my-vm"
-inputs = {
-  cpu_count = 4
-  mem_gb    = 16
-  hostname  = "example"
+vcfa_url           = "https://vcfa.lab.local"
+vcfa_refresh_token = "REDACTED"
+vcfa_organization  = "my-org"
+project_name       = "my-project"
+
+deployments = {
+  my_blueprint_deploy = {
+    catalog_item_name = "VM With Disks"
+    deployment_name   = "my-deploy-1"
+    description       = "Provisioned by TF"
+    inputs = {
+      flavorSize = "medium"
+      diskCount  = 2
+    }
+  }
 }
+
+virtual_machines = {}
 ```
 
-### 4. Initialize Terraform
-```bash
-terraform init
-```
+### 4. Initialize and apply
 
-### 5. Plan and Apply
 ```bash
+terraform init -backend-config="key=simpleiac/my-env.tfstate"
 terraform plan -var-file="envs/my-env.tfvars"
 terraform apply -var-file="envs/my-env.tfvars"
 ```
 
 ---
 
-## 📤 Outputs
+## Outputs
 
-The deployment exports:
-- Deployment ID  
-- Deployment name  
-- Resource map (each VM / disk / nic)  
-- IP address details  
-- Custom property results (if enabled)
-
-These can be consumed by downstream repos or pipelines.
+The deployment generates a rendered `output-template.tpl` file listing deployed VMs and their IP addresses.
 
 ---
 
-## 🧱 Module Reference
-
-See `Readme.md` for documentation of the reusable blueprint module.
-
----
-
-## 🤝 Contributing
-
-Feel free to open PRs if you'd like to contribute enhancements such as:
-- More flexible input validation
-- Event-driven follow-up integrations
-- Example downstream modules
-
----
-
-## 📜 License
+## License
 
 MIT — use freely in your lab, enterprise, or demos.


### PR DESCRIPTION
## Doc freshness pass — 2026-04-19

### Changes made
- **README.md**: Complete overhaul. The previous README described a `modules/blueprint-deploy/` local submodule (with `main.tf`, `variables.tf`, `outputs.tf`) that does not exist in the repo. Actual structure uses Terraform Registry modules (`sentania-labs/deployment/vra`, `sentania-labs/machine/vra`) via `deployments.tf` and `machines.tf`. Updated repo layout tree to match actual files. Fixed example variable names: `project_id`/`blueprint_id` don't exist as top-level vars; actual inputs are `project_name` + `deployments` map + `virtual_machines` map. Added correct backend init invocation.

### Drift flagged but not auto-fixed
- The README previously referenced `See Readme.md for documentation of the reusable blueprint module` — that file does not exist and the referenced module no longer exists as a local submodule. Removed the dead reference.
- `outputs.tf` referenced in old README does not exist in the repo. Current outputs are inline in `deployments.tf` via the registry module's outputs. No action needed but worth knowing if outputs.tf is planned.

Part of fleet-wide doc freshness pass 2026-04-19.